### PR TITLE
chore(deps): bump conda-incubator/setup-miniconda from 3.0.4 to 3.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v3.1.1
         with:
           use-mamba: true
           auto-update-conda: true
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Miniconda
-      uses: conda-incubator/setup-miniconda@v3.0.4
+      uses: conda-incubator/setup-miniconda@v3.1.1
       with:
         use-mamba: true
         auto-update-conda: true
@@ -100,7 +100,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Miniconda
-      uses: conda-incubator/setup-miniconda@v3.0.4
+      uses: conda-incubator/setup-miniconda@v3.1.1
       with:
         use-mamba: true
         auto-update-conda: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
           use-mamba: true
           auto-update-conda: true
           python-version: "3.9"
+          channels:
+            - defaults
       - name: Install dependencies
         run: |
           pip install ".[dev]"
@@ -52,6 +54,8 @@ jobs:
         use-mamba: true
         auto-update-conda: true
         python-version: ${{ matrix.python_version }}
+        channels:
+          - defaults
     - name: Install dependencies
       run: |
         pip install ".[dev]"
@@ -105,6 +109,8 @@ jobs:
         use-mamba: true
         auto-update-conda: true
         python-version: 3.9
+        channels:
+          - defaults
     - name: Build source distribution
       run: |
         python setup.py sdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         namedLogo: pytest
     - name: Upload Coverage to Codecov
       if: ${{ matrix.python_version == '3.13' && matrix.os == 'ubuntu-latest' }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -59,7 +59,7 @@ jobs:
         python setup.py test
     - name: Upload Coverage to Codecov
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v3.1.1
         with:
           use-mamba: true
           auto-update-conda: true
@@ -46,7 +46,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Miniconda
-      uses: conda-incubator/setup-miniconda@v3.0.4
+      uses: conda-incubator/setup-miniconda@v3.1.1
       with:
         use-mamba: true
         auto-update-conda: true

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -23,6 +23,8 @@ jobs:
           use-mamba: true
           auto-update-conda: true
           python-version: "3.9"
+          channels:
+            - defaults
       - name: Install dependencies
         run: |
           pip install ".[dev]"
@@ -51,6 +53,8 @@ jobs:
         use-mamba: true
         auto-update-conda: true
         python-version: ${{ matrix.python_version }}
+        channels:
+          - defaults
     - name: Install dependencies
       run: |
         pip install ".[dev]"


### PR DESCRIPTION
Fix setup-miniconda versions in CI manually because #61 is bugged.
Closes #61