### PR TITLE
New configuration option: 'per-feature-labels'

### DIFF
--- a/gutenTAG/anomalies/__init__.py
+++ b/gutenTAG/anomalies/__init__.py
@@ -63,7 +63,7 @@ class Anomaly:
             start, end = self.exact_position, self.exact_position + self.anomaly_length
 
         length = end - start
-        label_range = LabelRange(start, length)
+        label_range = LabelRange(start, length, self.channel)
         protocol = AnomalyProtocol(
             start,
             end,

--- a/gutenTAG/anomalies/types/__init__.py
+++ b/gutenTAG/anomalies/types/__init__.py
@@ -12,6 +12,7 @@ from ...utils.types import AnomalyGenerationContext
 class LabelRange:
     start: int
     length: int
+    channel: int
 
 
 @dataclass

--- a/gutenTAG/config/parser.py
+++ b/gutenTAG/config/parser.py
@@ -22,6 +22,7 @@ from ..utils.global_variables import (
 class GenerationOptions:
     semi_supervised: bool = False
     supervised: bool = False
+    per_feature_labels: bool = False
     dataset_name: Optional[str] = None
 
     def to_dict(self):
@@ -32,6 +33,7 @@ class GenerationOptions:
         return GenerationOptions(
             semi_supervised=d.get("semi-supervised", False),
             supervised=d.get("supervised", False),
+            per_feature_labels=d.get("per-feature-labels", False),
         )
 
 

--- a/gutenTAG/consolidator.py
+++ b/gutenTAG/consolidator.py
@@ -42,7 +42,7 @@ class Consolidator:
             if bo.timeseries is not None:
                 channels.append(bo.timeseries)
         self.timeseries = self._stack_channels(channels)
-        labels = np.zeros(self.timeseries.shape[0], dtype=np.int8)
+        labels = np.zeros((self.timeseries.shape[0], len(channels)), dtype=np.int8)
         self.labels = labels
         self.generate_anomalies(ctx)
 
@@ -99,4 +99,4 @@ class Consolidator:
                 "You need to call `generate` before applying anomalies!"
             )
         for label_range in label_ranges:
-            self.labels[label_range.start : label_range.start + label_range.length] = 1
+            self.labels[label_range.start : label_range.start + label_range.length, label_range.channel] = 1

--- a/gutenTAG/generator/timeseries.py
+++ b/gutenTAG/generator/timeseries.py
@@ -29,6 +29,7 @@ class TimeSeries:
         dataset_name: str,
         semi_supervised: bool = False,
         supervised: bool = False,
+        per_feature_labels: bool = False,
     ):
         self.dataset_name = dataset_name
         self.base_oscillations = base_oscillations
@@ -41,6 +42,7 @@ class TimeSeries:
         self.semi_train_labels: Optional[np.ndarray] = None
         self.semi_supervised = semi_supervised
         self.supervised = supervised
+        self.per_feature_labels = per_feature_labels
         self._rng_counter = 0
 
     def generate(self, random_seed: Optional[int] = None) -> TimeSeries:
@@ -180,7 +182,10 @@ class TimeSeries:
         channel_names = list(map(lambda i: f"value-{i}", range(ts.shape[1])))
         df = pd.DataFrame(ts, columns=channel_names)
         df.index.name = INDEX_COLUMN_NAME
-        df[LABEL_COLUMN_NAME] = labels
+        df[LABEL_COLUMN_NAME] = labels.max(axis=1)
+        if len(labels.shape) > 1 and self.per_feature_labels:
+            for i, col in enumerate(channel_names):
+                df[f"{LABEL_COLUMN_NAME}-{col}"] = labels[:, i]
         return df
 
     def to_csv(


### PR DESCRIPTION
I added an option 'per-feature-labels' that can either be set in the yaml files to be either true or false, but is false by default. It works by adding a 'channel' variable to the LabelRange dataclass, and then, if the option is set, adds a new column to the output csv for each channel, specifying whether this channel is anomalous. The original 'is-anomaly' is found by taking the max of all per channel labels, and is still added to the csv in both cases.

This is very useful to have when trying to do explainability studies on anomaly detection algorithms.

This is my first pull request, please let me know if anything is missing, or there is additional things I need to deliver/do :-) (Or if I've something completely stupid)