### PR TITLE
Fix trend anomaly for window lengths not divisible by 5

### DIFF
--- a/gutenTAG/anomalies/types/trend.py
+++ b/gutenTAG/anomalies/types/trend.py
@@ -27,8 +27,8 @@ class AnomalyTrend(BaseAnomaly):
             return anomaly_protocol
 
         length = anomaly_protocol.end - anomaly_protocol.start
-        transition_length = int(length * 0.2)
-        plateau_length = int(length * 0.8)
+        transition_length = max(1, int(length * 0.2))
+        plateau_length = length - transition_length
         start_transition = norm.pdf(np.linspace(-3, 0, transition_length), scale=1.05)
         amplitude_bell = np.concatenate(
             [start_transition / start_transition.max(), np.ones(plateau_length)]

--- a/tests/test_generator/test_trend_anomaly_length.py
+++ b/tests/test_generator/test_trend_anomaly_length.py
@@ -1,0 +1,54 @@
+import unittest
+from typing import Any, Dict
+
+from gutenTAG import GutenTAG
+
+
+class TestTrendAnomalyLength(unittest.TestCase):
+    """Regression tests for the trend-anomaly amplitude-envelope broadcast bug.
+
+    The envelope used to be built as ``int(length * 0.2) + int(length * 0.8)``
+    samples, which is one short of ``length`` whenever ``length`` is not a
+    multiple of 5, raising a NumPy broadcasting ``ValueError``. These tests
+    exercise window lengths covering every residue mod 5 (plus very small
+    lengths) to make sure the trend anomaly generates without error.
+    """
+
+    seed = 42
+
+    def _build_config(self, length: int) -> Dict[str, Any]:
+        return {
+            "timeseries": [
+                {
+                    "name": f"test-trend-{length}",
+                    "length": 500,
+                    "base-oscillations": [{"kind": "sine"}],
+                    "anomalies": [
+                        {
+                            "position": "middle",
+                            "length": length,
+                            "channel": 0,
+                            "kinds": [
+                                {"kind": "trend", "oscillation": {"kind": "sine"}}
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+    def test_trend_anomaly_length(self) -> None:
+        # Lengths cover every residue mod 5; non-multiples of 5 (e.g. 93, 94,
+        # 96, 97) used to crash, very small lengths (2, 3) guard the secondary
+        # transition_length == 0 edge case.
+        for length in [2, 3, 5, 11, 90, 93, 94, 95, 96, 97, 100]:
+            with self.subTest(length=length):
+                gutentag = GutenTAG(seed=self.seed)
+                gutentag.load_config_dict(self._build_config(length))
+                ts = gutentag.generate(return_timeseries=True)
+                self.assertIsNotNone(ts)
+                self.assertEqual(len(ts), 1)  # type: ignore
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
While doing some experiments for my master thesis, I noticed a tiny bug in how trend anomalies are created. 

There is a 20/80 split between `transition_length` and`plateau_length`. Truncating `int(length * 0.2)` and `int(length * 0.8)` independently loses one sample whenever `length` is not a multiple of 5, which made the amplitude envelope one sample shorter than the trend time series and broke the `*=` broadcast. An easy solution is to derive the `plateau_length` from the `transition_length` so that the two always sum to exactly `length`.

I ran the pre-commit hooks against both files (black, flake8, mypy, whitespace) — they pass. The only mypy warning is a pre-existing one in gutenTAG/config/validator.py, which I didn't touch.

I also added a test file `tests/test_generator/test_trend_anomaly_length.py`, which covers every residue mod 5 and fails for the old code and passes for the fix. 